### PR TITLE
upgrade @hapi/hapi due to a known vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@hapi/cookie": "10.1.0",
     "@hapi/good": "8.2.0",
     "@hapi/good-squeeze": "5.2.0",
-    "@hapi/hapi": "^18.4.0",
+    "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "5.2.1",
     "@hapi/joi": "15.1.0",
     "@hapi/vision": "5.5.2",


### PR DESCRIPTION
To complete the fix run `npm install` and commit the modified package-lock.json file